### PR TITLE
Fix for launching camera in landscape orientation

### DIFF
--- a/Sources/UIView+CameraBackground.swift
+++ b/Sources/UIView+CameraBackground.swift
@@ -53,6 +53,7 @@ public extension UIView {
         if showButtons {
             addCameraControls(margins: buttonMargins, location: buttonsLocation)
         }
+        cameraLayer.updateCameraFrameAndOrientation()
     }
 
     /// Take snapshot of the camera input shown in the background layer.


### PR DESCRIPTION
This is a simple fix for updating the AVCaptureVideoOrientation when launching in landscape mode. 

Resolves [issue 8](https://github.com/yonat/CameraBackground/issues/8)